### PR TITLE
implement resetting pyodide state without requiring a reload

### DIFF
--- a/src/event_handler.js
+++ b/src/event_handler.js
@@ -63,10 +63,8 @@ export class EventHandler {
             this.setMessagePassingState({ paused: true });
             return;
         }
-
         this.setMessagePassingState({ paused: false });
         this.setMessagePassingState({ paused: true });
-
     }
 
     sendUserInputToWorker(event) {
@@ -86,9 +84,8 @@ export class EventHandler {
         const waitArray = new Int32Array(globals.getCurrentSAB(), 0, 2);
         Atomics.store(waitArray, 0, 1); // this is for stopping the wait
         Atomics.notify(waitArray, 0, 1);
-        Atomics.store(waitArray, 1, 1);     // this is for checking if we've reset the game
-        // Atomics.notify(waitArray, 1, 1); // there is nobody waiting on this so no need to notify
-        this.worker.postMessage({type: "reset"});
+        Atomics.store(waitArray, 1, 1); // this is for checking (in worker) if we've reset the game
+        //this.worker.postMessage({type: "reset"});
     }
 
     #postMessageToWorker(message) {

--- a/src/event_handler.js
+++ b/src/event_handler.js
@@ -82,14 +82,13 @@ export class EventHandler {
         }
     }
 
-    restartWorker() {
-        console.log("asd");
+    resetWorker() {
         const waitArray = new Int32Array(globals.getCurrentSAB(), 0, 2);
-        Atomics.store(waitArray, 0, 1);
+        Atomics.store(waitArray, 0, 1); // this is for stopping the wait
         Atomics.notify(waitArray, 0, 1);
-        Atomics.store(waitArray, 1, 1);
-        Atomics.notify(waitArray, 1, 1);
-        this.worker.postMessage({type: "restart"});
+        Atomics.store(waitArray, 1, 1);     // this is for checking if we've reset the game
+        // Atomics.notify(waitArray, 1, 1); // there is nobody waiting on this so no need to notify
+        this.worker.postMessage({type: "reset"});
     }
 
     #postMessageToWorker(message) {

--- a/src/input/worker.js
+++ b/src/input/worker.js
@@ -24,7 +24,8 @@ self.onmessage = async function (event) {
         runPythonCode(pyodide, message.details);
     }
     if (message.type === 'reset') {
-        setResetFlag(true);
+        console.log("This should never print");
+        // setResetFlag(true);
     }
 }
 
@@ -96,6 +97,7 @@ function runCommand(command, parameters) {
     ctr++;
     console.log(ctr + " hyppyä");
 
+    // waitarray[1] will be "1" if resetWorker() is called in event handler, otherwise 0
     if (waitArray[1] === 0) {
         try {
             continuePythonExecution;
@@ -126,8 +128,7 @@ async function runPythonCode(pyodide, codeString) {
         await pyodide.runPythonAsync(`print(check_while_usage("""${codeString}"""))`);
 
         try {
-            // reset pyodide state to where we saved it earlier after we're done
-            // for some reason, this will currently throw an error
+            // reset pyodide state to where we saved it earlier after all commands are done
             pyodide.pyodide_py._state.restore_state(state);
         } catch (error) {
             postError(error.message);
@@ -136,6 +137,7 @@ async function runPythonCode(pyodide, codeString) {
         // no more python left to run; let the event handler know
         postMessage({ type: 'finish' });
     } catch (error) {
+        // also reset pyodide state on errors/exceptions such as when we reset the game mid-execution
         pyodide.pyodide_py._state.restore_state(state);
         postError(error.message);
     }

--- a/src/input/worker.js
+++ b/src/input/worker.js
@@ -37,7 +37,7 @@ async function initializePyodide(pythonCode) {
     if (pyodide === undefined) {
         // eslint-disable-next-line no-undef
         pyodide = await loadPyodide();
-        pyodide.globals.set("reset_flag", resetFlag);
+        state = pyodide.pyodide_py._state.save_state(); // we save pyodide initial state to restore if needed
 
         pyodide.setStdin({
             stdin: () => {
@@ -136,6 +136,7 @@ async function runPythonCode(pyodide, codeString) {
         // no more python left to run; let the event handler know
         postMessage({ type: 'finish' });
     } catch (error) {
+        pyodide.pyodide_py._state.restore_state(state);
         postError(error.message);
     }
 }

--- a/src/python/pelaaja.py
+++ b/src/python/pelaaja.py
@@ -16,6 +16,11 @@ class Pelaaja:
         self.__directions =  ["oikea", "vasen", "ylös", "alas"]
 
     def liiku(self, direction: str):
+        print(reset_flag)
+        if reset_flag:
+            js.asd = "stop"
+            print("execution stopped due to reset")
+            return False
         if direction in self.__directions:
             js.runCommand("move", direction)
         else:

--- a/src/python/pelaaja.py
+++ b/src/python/pelaaja.py
@@ -16,11 +16,8 @@ class Pelaaja:
         self.__directions =  ["oikea", "vasen", "ylös", "alas"]
 
     def liiku(self, direction: str):
-        print(reset_flag)
         if reset_flag:
-            js.asd = "stop"
-            print("execution stopped due to reset")
-            return False
+            raise Exception("Interpreter was reset")
         if direction in self.__directions:
             js.runCommand("move", direction)
         else:

--- a/src/ui.js
+++ b/src/ui.js
@@ -31,9 +31,7 @@ function initialize() {
             displayErrorMessage(error);
         }
     } else {
-        //let pythonFileStr = fileReader.tryGetFileAsText("./src/python/pelaaja.py");
-        //eventHandler.postMessage({ type: 'restart' });
-        eventHandler.restartWorker()
+        eventHandler.resetWorker()
     }
 }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -4,9 +4,12 @@ import * as fileReader from "./file_reader.js";
 import * as editor from "./input/editor.js";
 import * as errorHandler from "./input/py_error_handling.js";
 import { EventHandler } from "./event_handler.js";
+//import { initPyodide } from "./input/worker.js";
 
 let eventHandler;
 let state = { current: "initial" };
+let worker = new Worker('/src/input/worker.js');
+let initialized = false;
 
 async function main() {
     initialize();
@@ -16,14 +19,21 @@ async function main() {
 }
 
 function initialize() {
-    if (String(typeof eventHandler) === "object") eventHandler.terminateWorker();
-    eventHandler = new EventHandler();
-
-    try {
-        let pythonFileStr = fileReader.tryGetFileAsText("./src/python/pelaaja.py");
-        eventHandler.postMessage({ type: 'init', details: pythonFileStr });
-    } catch (error) {
-        displayErrorMessage(error);
+    //    if (String(typeof eventHandler) === "object") eventHandler.terminateWorker();
+    // if (String(typeof eventHandler) === "object") worker.pyodide_py._state.restore_state(pyodideInitialState);
+    eventHandler = new EventHandler(getWorker());
+    if (!initialized) {
+        try {
+            let pythonFileStr = fileReader.tryGetFileAsText("./src/python/pelaaja.py");
+            eventHandler.postMessage({ type: 'init', details: pythonFileStr });
+            initialized = true;
+        } catch (error) {
+            displayErrorMessage(error);
+        }
+    } else {
+        //let pythonFileStr = fileReader.tryGetFileAsText("./src/python/pelaaja.py");
+        //eventHandler.postMessage({ type: 'restart' });
+        eventHandler.restartWorker()
     }
 }
 
@@ -169,13 +179,17 @@ export function getEventHandler() {
     return eventHandler;
 }
 
+function getWorker() {
+    return worker;
+}
+
 /**
  * Used to do something after there is no more python code to run.
  * This is probably where we want to check if the user has achieved the win conditions and display some kind
  * of "congratulations, you are a winner" message if so.
  */
 export function onFinishLastCommand() {
-    disablePlayButtonsOnFinish();
+    //disablePlayButtonsOnFinish();
     console.log("Last command finished. Called from index.js.");
 }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -187,7 +187,7 @@ function getWorker() {
  * of "congratulations, you are a winner" message if so.
  */
 export function onFinishLastCommand() {
-    //disablePlayButtonsOnFinish();
+    disablePlayButtonsOnFinish();
     console.log("Last command finished. Called from index.js.");
 }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -4,7 +4,6 @@ import * as fileReader from "./file_reader.js";
 import * as editor from "./input/editor.js";
 import * as errorHandler from "./input/py_error_handling.js";
 import { EventHandler } from "./event_handler.js";
-//import { initPyodide } from "./input/worker.js";
 
 let eventHandler;
 let state = { current: "initial" };
@@ -19,9 +18,8 @@ async function main() {
 }
 
 function initialize() {
-    //    if (String(typeof eventHandler) === "object") eventHandler.terminateWorker();
-    // if (String(typeof eventHandler) === "object") worker.pyodide_py._state.restore_state(pyodideInitialState);
     eventHandler = new EventHandler(getWorker());
+
     if (!initialized) {
         try {
             let pythonFileStr = fileReader.tryGetFileAsText("./src/python/pelaaja.py");
@@ -188,7 +186,7 @@ function getWorker() {
  */
 export function onFinishLastCommand() {
     disablePlayButtonsOnFinish();
-    console.log("Last command finished. Called from index.js.");
+    console.log("Last command finished");
 }
 
 /**

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -18,6 +18,18 @@ export const collectibles = { total: task.getTotalCollectibles(), current: 0 };
 export const conditions = task.getConditions();
 export const conditionsCleared = [];
 
+export let currentSAB;
+
+export let asd = false;
+
+export function setCurrentSAB(sab) {
+    currentSAB = sab;
+}
+
+export function getCurrentSAB() {
+    return currentSAB;
+}
+
 export function incrementCollectibles() {
     collectibles.current += 1;
 }


### PR DESCRIPTION
There is a pretty decent chance this will cause some unexpected side effects, but the worker now resets without requiring a reload,  meaning no delays after the initial page load. Whatever bugs this will cause should be easier to figure out than figuring this out was, at least.

closes #88 