### PR TITLE
fix element (mainly canvas) pop in on page reload

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -50,8 +50,9 @@ body {
     flex-direction: column;
 }
 
-#left-container {
+#left-container, #right-container {
     min-width: var(--canvas-width);
+    min-height: var(--canvas-height);
     justify-content: space-between;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -52,8 +52,11 @@ body {
 
 #left-container, #right-container {
     min-width: var(--canvas-width);
-    min-height: var(--canvas-height);
     justify-content: space-between;
+}
+
+#right-container {
+    min-height: var(--canvas-height);
 }
 
 .is-margin-half-rem-x {

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                 </div>
             </div>
             <div id="header-buttons" class="is-flex">
-                <div id="user-container" class="is-flex">
+                <div id="user-container" class="is-flex is-hidden">
                     <input id="username" placeholder="username">
                     <input type="password" id="password" placeholder="********">
                     <button id="login-button" value="login">Kirjaudu sisään</button>
@@ -94,7 +94,7 @@
                 </div>
             </div>
             <div id="right-container">
-                
+
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -93,6 +93,9 @@
                     <div id="input-container" class="is-margin-half-rem-x is-flex-1 is-hidden"></div>
                 </div>
             </div>
+            <div id="right-container">
+                
+            </div>
         </div>
     </div>
     <div id="task-selector-container" class="is-flex">

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -27,7 +27,7 @@ async function main() {
  */
 async function initGameAndCanvas() {
     let canvas = await initGame();
-    document.getElementById("left-container").insertAdjacentElement("afterend", canvas);
+    document.getElementById("right-container").insertAdjacentElement("afterbegin", canvas);
     canvas.classList.add("is-flex");
     canvas.id = "game";
     setTheme(localStorage.getItem("theme"));

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -111,8 +111,9 @@ async function initPage() {
 
 function isUserLoggedIn() {
     if (localStorage.getItem("token") !== null) {
-        document.getElementById("user-container").classList.add("is-hidden");
         document.getElementById("logout-button").classList.remove("is-hidden");
+    } else {
+        document.getElementById("user-container").classList.remove("is-hidden");
     }
 }
 


### PR DESCRIPTION
closes #184 
- canvas still has to load in, but there's a placeholder element that takes roughly the same space to reduce "pop in"
- login fields are unhidden if user **is not** logged in instead of hidden if user **is** logged in to avoid "pop out"